### PR TITLE
[TEST] GraphQL Select 테스트 추가

### DIFF
--- a/src/main/java/com/sbkim/springboot_graphql/domain/Comment.java
+++ b/src/main/java/com/sbkim/springboot_graphql/domain/Comment.java
@@ -1,6 +1,5 @@
 package com.sbkim.springboot_graphql.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,10 +8,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(name = "COMMENTS")
@@ -26,7 +23,20 @@ public class Comment extends BaseEntity{
 
     private String commentBody;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "content_id")
     private Content content;
+
+    protected Comment() {
+    }
+
+    private Comment(String commentBody, Content content) {
+        this.commentBody = commentBody;
+        this.content = content;
+    }
+
+    public static Comment of(String commentBody, Content content) {
+        return new Comment(commentBody, content);
+    }
 }

--- a/src/main/java/com/sbkim/springboot_graphql/domain/Content.java
+++ b/src/main/java/com/sbkim/springboot_graphql/domain/Content.java
@@ -1,16 +1,14 @@
 package com.sbkim.springboot_graphql.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import lombok.Getter;
-import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(name = "CONTENTS")
@@ -27,4 +25,22 @@ public class Content extends BaseEntity {
 
     @OneToMany
     private List<Comment> commentList;
+
+    protected Content() {
+    }
+
+    public Content(String contentTitle, String contentBody) {
+        this.contentTitle = contentTitle;
+        this.contentBody = contentBody;
+        this.commentList = new ArrayList<>();
+    }
+
+    public static Content of(String contentTitle, String contentBody) {
+        return new Content(contentTitle, contentBody);
+    }
+
+    public void addComment(Comment comment) {
+        this.commentList.add(comment);
+        comment.setContent(this);
+    }
 }

--- a/src/test/java/com/sbkim/springboot_graphql/GraphQLTest.java
+++ b/src/test/java/com/sbkim/springboot_graphql/GraphQLTest.java
@@ -5,7 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.graphql.spring.boot.test.GraphQLResponse;
 import com.graphql.spring.boot.test.GraphQLTestTemplate;
+import com.sbkim.springboot_graphql.domain.Comment;
+import com.sbkim.springboot_graphql.domain.Content;
+import com.sbkim.springboot_graphql.repository.CommentRepository;
+import com.sbkim.springboot_graphql.repository.ContentRepository;
 import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,14 +25,49 @@ public class GraphQLTest {
 
     @Autowired
     private GraphQLTestTemplate graphQLTestTemplate;
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private ContentRepository contentRepository;
 
-    @Test
+    String contentTitle = "TEST_CONTENT_TITLE";
+    String contentBody = "TEST_CONTENT_BODY";
+    String commentBody = "TEST_COMMNET_BODY";
+
+    @BeforeEach
+    void init() {
+        Content content = Content.of(contentTitle, contentBody);
+        content = contentRepository.save(content);
+        Comment comment = Comment.of(commentBody, content);
+        comment = commentRepository.save(comment);
+        content.addComment(comment);
+    }
+
     @DisplayName("GraphQL 설정이 정상적으로 작동하는지를 확인한다.")
+    @Test
     void queryTEST() throws IOException {
+
+        // when
         GraphQLResponse response = this.graphQLTestTemplate.postForResource("queryTest.graphql");
 
+        // then
         System.out.println(response.readTree().toString());
-
         assertTrue(response.isOk());
+    }
+
+    @DisplayName("GraphQL 의 응답 결과가 예상과 맞는지 확인한다.")
+    @Test
+    public void givenContentAndComment_whenRequest_thenReturnData() throws Exception {
+
+        //when
+        GraphQLResponse response = this.graphQLTestTemplate.postForResource("queryTest.graphql");
+
+        //then
+        assertTrue(response.isOk());
+        assertEquals("1", response.get("$.data.contentList[0].contentId"));
+        assertEquals(contentTitle, response.get("$.data.contentList[0].contentTitle"));
+        assertEquals(contentBody, response.get("$.data.contentList[0].contentBody"));
+        assertEquals("1", response.get("$.data.contentList[0].commentList[0].commentId"));
+        assertEquals(commentBody, response.get("$.data.contentList[0].commentList[0].commentBody"));
     }
 }


### PR DESCRIPTION
- GraphQLTest 에 GraphQL 을 통해서 온 응답을 테스트하는 코드 추가
- GraphQL 은 post 요청을 통해서 조회 결과를 얻을 수 있다. 
- 미리 지정한 형식에 따라서 응답이 오고, 데이터의 정합성을 확인했다.