### PR TITLE
Celery/celery with java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-graphql</artifactId>
     </dependency>
-
+    <!-- MQ Consumer 로 Celery 사용 -->
+    <dependency>
+      <groupId>com.geneea.celery</groupId>
+      <artifactId>celery-java</artifactId>
+      <version>1.10.4</version>
+    </dependency>
     <!--    frontend 로 jquery + mustache 사용-->
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -51,7 +56,7 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
 
-<!--    postgresql driver-->
+    <!--    postgresql driver-->
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>

--- a/src/main/java/com/sbkim/springboot_graphql/service/CeleryRecommendServiceImpl.java
+++ b/src/main/java/com/sbkim/springboot_graphql/service/CeleryRecommendServiceImpl.java
@@ -1,0 +1,48 @@
+package com.sbkim.springboot_graphql.service;
+
+import com.geneea.celery.Celery;
+import com.sbkim.springboot_graphql.domain.Content;
+import com.sbkim.springboot_graphql.service.interfaces.CeleryRecommendService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class CeleryRecommendServiceImpl implements CeleryRecommendService {
+
+    @Value("${rabbitmq.brokerUri}")
+    private String brokerUri;
+
+    @Value("${rabbitmq.backendUri}")
+    private String backendUri;
+
+
+    @Override
+    public List<Content> getRecommendedContent(String userId) {
+
+        try {
+            Celery celeryClient = Celery.builder()
+                .brokerUri(brokerUri)
+                .backendUri(backendUri)
+                .queue("task_get_queue0001")
+                .build();
+            List<List<String>> celeryResult = (List<List<String>>) celeryClient.submit(
+                "task.get.recommend.queue", new Object[]{userId}).get();
+
+            List<Content> contentList = new ArrayList<>();
+            for (List<String> data : celeryResult) {
+                Content content = Content.of(data.get(0), data.get(1));
+                contentList.add(content);
+            }
+
+            return contentList;
+        } catch (Exception e) {
+            log.warn("Failed to get recommended content");
+        }
+
+        return List.of();
+    }
+}

--- a/src/main/java/com/sbkim/springboot_graphql/service/interfaces/CeleryRecommendService.java
+++ b/src/main/java/com/sbkim/springboot_graphql/service/interfaces/CeleryRecommendService.java
@@ -1,0 +1,15 @@
+package com.sbkim.springboot_graphql.service.interfaces;
+
+import com.sbkim.springboot_graphql.domain.Content;
+import java.util.List;
+
+public interface CeleryRecommendService {
+
+    /**
+     * 사용자에게 추천 Content 를 가져오는 Celery Node 를 호출한다.
+     *
+     * @param userId
+     */
+    List<Content> getRecommendedContent(String userId);
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,7 @@ spring.graphql.graphiql.enabled=true;
 # H2 db ??
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+#RabbitMQ
+#todo properties ? id pw ? ?????? ??
+rabbitmq.brokerUri="amqp://admin:admin@12.34.56.72:5672"
+rabbitmq.backendUri="rpc://admin:admin@12.34.56.72:5672"

--- a/src/test/java/com/sbkim/springboot_graphql/service/CeleryRecommendServiceImplTest.java
+++ b/src/test/java/com/sbkim/springboot_graphql/service/CeleryRecommendServiceImplTest.java
@@ -1,0 +1,20 @@
+package com.sbkim.springboot_graphql.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CeleryRecommendServiceImplTest {
+
+    @Autowired
+    private CeleryRecommendServiceImpl celeryRecommendService;
+
+    @Test
+    void getRecommendedContent() {
+        var celeryResponse = celeryRecommendService.getRecommendedContent("1234");
+        assertTrue(celeryResponse.size() > 1);
+    }
+}


### PR DESCRIPTION
Spring Boot + RabbitMQ + Celery 를 구현했다.
비동기 처리 분산 노드로 Celery 를 채택했다. Celery 는 확장성에 매우 유연하고 사용이 쉽기 때문이다.
사용자 요청 -> Spring Boot Was -> RabbitMQ -> Celery (무거운 로직 처리) 의 작업을 거친다.

Celery Node 를 호출하기 위해서는 요청시에도 Celery Spec 을 맞춰야 한다. 따라서 Python Celery 를 사용하는 것이 일반적이지만 Spring WAS 에서 Celery 요청을 위해서 Python 코드를 ProcessExecutor 로 호출하는 코드는 어렵고 직관성이 낮다.

예시)
```
            ProcessBuilder processBuilder = new ProcessBuilder("python", "-c", "print('Hello, Python!')");
            Process process = processBuilder.start();
            InputStream inputStream = process.getInputStream();
            BufferedReader reader = new BufferedReader(new `InputStreamReader(inputStream));
```

따라서 java-celery 라이브러리를 사용해서 Celery 노드를 호출하는 방법을 채택했다.
단, 해당 라이브러리의 마지막 커밋이 2년전이고, star 가 낮아서 신뢰성에 대해서는 좀 더 확인이 필요할 것 같다.